### PR TITLE
Fix dockerization image dublication issue, add reset_db

### DIFF
--- a/Application/Backend/docker-compose.yml
+++ b/Application/Backend/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   database:
+    image: medishare.database
     build:
       context: ./docker_database
     env_file:
@@ -10,6 +11,7 @@ services:
     networks:
       - db-backend
   backend:
+    image: medishare.backend
     build:
       context: .
       dockerfile: ./docker_backend/Dockerfile
@@ -24,6 +26,19 @@ services:
       - database
     networks:
       - db-backend
+
+  reset-db:
+    profiles: 
+      - tools
+    image: medishare.database
+    build:
+      context: ./docker_database
+    env_file:
+      - .env
+    volumes:
+      - ./_temp_db:/var/lib/mysql
+    command:
+      - ./reset_db.sh
 
 networks:
   db-backend:

--- a/Application/Backend/docker_backend/init_backend.sh
+++ b/Application/Backend/docker_backend/init_backend.sh
@@ -16,6 +16,7 @@ done
 # Update database and run the server
 python manage.py makemigrations
 python manage.py migrate --run-syncdb
+python manage.py migrate --run-syncdb
 
 # Create debug superuser if username given
 if [ "$DJANGO_SUPERUSER_USERNAME" ]

--- a/Application/Backend/docker_database/Dockerfile
+++ b/Application/Backend/docker_database/Dockerfile
@@ -1,4 +1,10 @@
 FROM mysql/mysql-server:8.0
 
+WORKDIR /tools
+
 COPY ./init_db.sh /docker-entrypoint-initdb.d/
 RUN chmod +x /docker-entrypoint-initdb.d/init_db.sh
+
+ADD https://raw.githubusercontent.com/dr5hn/countries-states-cities-database/v1.9/sql/world.sql /tools
+COPY ./reset_db.sh /tools/
+RUN chmod +x /tools/reset_db.sh

--- a/Application/Backend/docker_database/init_db.sh
+++ b/Application/Backend/docker_database/init_db.sh
@@ -1,6 +1,3 @@
 #!/bin/bash
 
-mysql -u root --password="$MYSQL_ROOT_PASSWORD"  << EOF
-USE ${MYSQL_DATABASE};
-GRANT ALL PRIVILEGES ON  test_${MYSQL_DATABASE}.* TO '${MYSQL_USER}';
-EOF
+mysql -u ${MYSQL_USER} --password="$MYSQL_ROOT_PASSWORD" -D $MYSQL_DATABASE < /tools/world.sql

--- a/Application/Backend/docker_database/reset_db.sh
+++ b/Application/Backend/docker_database/reset_db.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+mysqld &
+
+# Wait for database to respond
+while :
+do
+    (echo -n > /dev/tcp/127.0.0.1/$MYSQL_DATABASE_PORT) >/dev/null 2>&1
+    WAITFORIT_result=$?
+    if [[ $WAITFORIT_result -eq 0 ]]; then
+        echo "Database responded!"
+        break
+    fi
+    echo "Waiting for database..."
+    sleep 5
+done
+
+mysql -u root --password="$MYSQL_ROOT_PASSWORD" -D $MYSQL_DATABASE << EOF
+SET SESSION group_concat_max_len = 1000000;
+-- build dynamic sql (DROP TABLE tbl1, tbl2...;)
+SELECT CONCAT('DROP TABLE ',GROUP_CONCAT(CONCAT('${MYSQL_DATABASE}','.',table_name)),';')
+INTO @droplike
+FROM information_schema.tables
+WHERE table_name NOT IN ('cities', 'states', 'countries')
+AND table_schema='${MYSQL_DATABASE}';
+
+-- display the dynamic sql statement
+SELECT @droplike;
+
+-- execute dynamic sql
+PREPARE stmt FROM @droplike;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+EOF

--- a/Application/Frontend/docker-compose.yml
+++ b/Application/Frontend/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       file: ../Backend/docker-compose.yml
       service: database
   frontend:
+    image: medishare.frontend
     build:
       context: .
     command: npm start


### PR DESCRIPTION
This pull request will fix following issues:
* Docker Compose configuration file seperation for Backend and Frontend has created an image dublication problem. This should be fixed.
* For Backend, a command to reset database without completely deleting it has been requested.
