### PR TITLE
Content Models Added

### DIFF
--- a/Application/Backend/src/contmgr/admin.py
+++ b/Application/Backend/src/contmgr/admin.py
@@ -1,3 +1,5 @@
 from django.contrib import admin
+from .models import *
 
-# Register your models here.
+admin.site.register(Comment)
+admin.site.register(Post)

--- a/Application/Backend/src/contmgr/models.py
+++ b/Application/Backend/src/contmgr/models.py
@@ -12,3 +12,10 @@ class Content(models.Model):
 
     class Meta:
         abstract = True
+
+class Comment(Content):
+
+    commentID = models.AutoField(primary_key=True)
+    # only one of the following two fields will be set
+    parent_comment = models.ForeignKey("self", on_delete=models.CASCADE, blank=True, null=True, related_name='children_comments')
+    parent_post = models.ForeignKey("Post", on_delete=models.CASCADE, blank=True, null=True, related_name='children_comments')

--- a/Application/Backend/src/contmgr/models.py
+++ b/Application/Backend/src/contmgr/models.py
@@ -1,3 +1,11 @@
 from django.db import models
+from django.utils import timezone
+from src.accmgr.models import *
 
-# Create your models here.
+class Content(models.Model):
+
+    owner = models.ForeignKey(RegisteredUser, on_delete=models.CASCADE, blank=False, null=False)
+    description = models.CharField(max_length=10000, blank=False, null=False)
+    vote_count = models.IntegerField(default=0)
+    created_at = models.DateTimeField(default=timezone.now())
+    mentioned_users = models.ManyToManyField(RegisteredUser, related_name='mentioned_by_%(class)s', blank=True)

--- a/Application/Backend/src/contmgr/models.py
+++ b/Application/Backend/src/contmgr/models.py
@@ -9,3 +9,6 @@ class Content(models.Model):
     vote_count = models.IntegerField(default=0)
     created_at = models.DateTimeField(default=timezone.now())
     mentioned_users = models.ManyToManyField(RegisteredUser, related_name='mentioned_by_%(class)s', blank=True)
+
+    class Meta:
+        abstract = True

--- a/Application/Backend/src/contmgr/models.py
+++ b/Application/Backend/src/contmgr/models.py
@@ -19,3 +19,22 @@ class Comment(Content):
     # only one of the following two fields will be set
     parent_comment = models.ForeignKey("self", on_delete=models.CASCADE, blank=True, null=True, related_name='children_comments')
     parent_post = models.ForeignKey("Post", on_delete=models.CASCADE, blank=True, null=True, related_name='children_comments')
+
+class Post(Content):
+
+    postID = models.AutoField(primary_key=True)
+
+    POST_TYPES = (
+        ("i", "information"),
+        ("q", "question"),
+        ("a", "advice"),
+        ("e", "experience")
+    )
+    
+    title = models.CharField(max_length=256, blank=False, null=False)
+    type = models.CharField(max_length=1, choices=POST_TYPES, default="e")
+    location = models.CharField(max_length=128, blank=True, null=True, default=None)
+    imageURL = models.CharField(max_length=256, blank=True, null=True, default=None)
+    is_marked_nsfw = models.BooleanField(default=False)
+    # content_labels = models.ManyToManyField(ContentLabel, related_name='content_labels', blank=True)
+    # field_labels = models.ManyToManyField(FieldLabel, related_name='field_labels', blank=True)


### PR DESCRIPTION
The Django models for the Content, Post, and Comment classes are added in accordance with issues #278, #279, and #280.
Note that the Content model is an abstract class that has no direct instance of itself. The Post and Comment classes inherit from the Content class for their shared fields as described in the issues and the class diagram. 

However, unlike the class diagram, they do not share a common ID system because it goes against the relational database principles. For this implementation, they have separate tables and separate primary keys (IDs).

Please tag me in the comments or contact me directly if there's any bug in the code.