### PR TITLE
Get All Posts Endpoint Added

### DIFF
--- a/Application/Backend/src/contmgr/urls.py
+++ b/Application/Backend/src/contmgr/urls.py
@@ -14,4 +14,6 @@ urlpatterns = [
     path('commentvote', views.CommentVote.as_view(), name='comment'),
     path('postvote/', views.PostVote.as_view(), name='post'),
     path('commentvote/', views.CommentVote.as_view(), name='comment'),
+    path('allposts', views.AllPostsView.as_view(), name='allposts'),
+    path('allposts/', views.AllPostsView.as_view(), name='allposts/'),
 ]

--- a/Application/Backend/src/contmgr/views.py
+++ b/Application/Backend/src/contmgr/views.py
@@ -2,7 +2,7 @@ from rest_framework.views import APIView
 from django.http import JsonResponse
 from .models import *
 from ..accmgr.models import *
-from rest_framework.permissions import BasePermission, IsAuthenticated
+from rest_framework.permissions import BasePermission, IsAuthenticated, AllowAny
 
 
 class IsGetOrIsAuthenticated(BasePermission):
@@ -235,3 +235,16 @@ class PostView(APIView):
             return JsonResponse({"info": "post creation successful", "postID": new_post.postID}, status=201)
         except Exception as e:
             return JsonResponse({"info":"post creation failed", "error": str(e)}, status=400)
+
+class AllPostsView(APIView):
+
+    permission_classes = (AllowAny,)
+
+    def get(self, req):
+        
+        posts = Post.objects.all().order_by('-created_at')
+        data = {"posts":[]}
+        for post in posts:
+            data["posts"].append(post.as_dict())
+
+        return JsonResponse(data, status=200)


### PR DESCRIPTION
An andpoint for getting all posts has been added. This endpoint is available at /contmgr/allposts or /contmgr/allposts/. This endpoint returns a list of all posts sorter from new to old in the same form as returned in the search endpoint (with the as_dict() method).