### PR TITLE
Annotation Support for Backend Implemented

### DIFF
--- a/Application/Backend/api_docs/annotations_api_doc.json
+++ b/Application/Backend/api_docs/annotations_api_doc.json
@@ -1,0 +1,1767 @@
+{
+	"info": {
+		"_postman_id": "98192e63-288f-4e90-a0fd-14633e4dee54",
+		"name": "Annotations",
+		"description": "# Introduction\n\nThis endpoint is used for creating and deleting text and image annotations on posts and comments\n\nThe endpoints\n\n- annotations/\n- annotations\n    \n\nhave exactly the same functionality\n\n# Overview\n\nThe .jsonld given should be valid.\n\n# Authentication\n\nAuthentication is needed to use this endpoint\n\n# Error Codes\n\n200: Annotation creation or deletion is successful.\n\n400: Annotation creation or deletion failed because of bad request.\n\n404: Annotation target does not exist.",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "24070174"
+	},
+	"item": [
+		{
+			"name": "Text Create Success",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "annotation_type",
+							"value": "text",
+							"type": "text"
+						},
+						{
+							"key": "content_type",
+							"value": "post",
+							"type": "text"
+						},
+						{
+							"key": "content_id",
+							"value": "1",
+							"type": "text"
+						},
+						{
+							"key": "jsonld",
+							"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"text annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":\"1\",\"name\":\"tollen\"},\"created\":\"2022-12-23T14:48:30.744Z\",\"modified\":\"2022-12-23T14:48:38.590Z\"}],\"target\":{\"selector\":[{\"type\":\"TextQuoteSelector\",\"exact\":\"Annotations\"},{\"type\":\"TextPositionSelector\",\"start\":14,\"end\":25}]},\"id\":\"#5519fef0-7376-4630-96f8-4b6407419c13\"}",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "localhost:8000/contmgr/annotations/",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"contmgr",
+						"annotations",
+						""
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Create Success",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "text",
+									"type": "text"
+								},
+								{
+									"key": "content_type",
+									"value": "post",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"text annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":\"1\",\"name\":\"tollen\"},\"created\":\"2022-12-23T14:48:30.744Z\",\"modified\":\"2022-12-23T14:48:38.590Z\"}],\"target\":{\"selector\":[{\"type\":\"TextQuoteSelector\",\"exact\":\"Annotations\"},{\"type\":\"TextPositionSelector\",\"start\":14,\"end\":25}]},\"id\":\"#5519fef0-7376-4630-96f8-4b6407419c13\"}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 18:59:14 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "100"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation successful\",\n    \"annotation_id\": \"#5519fef0-7376-4630-96f8-4b6407419c13\"\n}"
+				},
+				{
+					"name": "Create Success",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "text",
+									"type": "text"
+								},
+								{
+									"key": "content_type",
+									"value": "post",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"text annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":\"1\",\"name\":\"tollen\"},\"created\":\"2022-12-23T14:48:30.744Z\",\"modified\":\"2022-12-23T14:48:38.590Z\"}],\"target\":{\"selector\":[{\"type\":\"TextQuoteSelector\",\"exact\":\"Annotations\"},{\"type\":\"TextPositionSelector\",\"start\":14,\"end\":25}]},\"id\":\"#5519fef0-7376-4630-96f8-4b6407419c13\"}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:04:27 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "79"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation failed\",\n    \"error\": \"annotation_id already exists\"\n}"
+				}
+			]
+		},
+		{
+			"name": "Image Create Success",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "annotation_type",
+							"value": "image",
+							"type": "text"
+						},
+						{
+							"key": "content_id",
+							"value": "1",
+							"type": "text"
+						},
+						{
+							"key": "jsonld",
+							"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"image annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":1,\"name\":\"tollen\"},\"created\":\"2022-12-23T14:55:40.253Z\",\"modified\":\"2022-12-23T14:55:41.743Z\"}],\"target\":{\"source\":\"https://myuploads-medishare38.s3.amazonaws.com/image_1671788232333.png\",\"selector\":{\"type\":\"FragmentSelector\",\"conformsTo\":\"http://www.w3.org/TR/media-frags/\",\"value\":\"xywh=pixel:68,76,194,196\"}},\"id\":\"#48d7b458-fead-45af-b317-db2d9ddf4c38\"}",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "localhost:8000/contmgr/annotations/",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"contmgr",
+						"annotations",
+						""
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Image Create Success",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "image",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"image annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":1,\"name\":\"tollen\"},\"created\":\"2022-12-23T14:55:40.253Z\",\"modified\":\"2022-12-23T14:55:41.743Z\"}],\"target\":{\"source\":\"https://myuploads-medishare38.s3.amazonaws.com/image_1671788232333.png\",\"selector\":{\"type\":\"FragmentSelector\",\"conformsTo\":\"http://www.w3.org/TR/media-frags/\",\"value\":\"xywh=pixel:68,76,194,196\"}},\"id\":\"#48d7b458-fead-45af-b317-db2d9ddf4c38\"}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:10:11 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "100"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation successful\",\n    \"annotation_id\": \"#48d7b458-fead-45af-b317-db2d9ddf4c38\"\n}"
+				},
+				{
+					"name": "Image Create Success",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "image",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"image annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":1,\"name\":\"tollen\"},\"created\":\"2022-12-23T14:55:40.253Z\",\"modified\":\"2022-12-23T14:55:41.743Z\"}],\"target\":{\"source\":\"https://myuploads-medishare38.s3.amazonaws.com/image_1671788232333.png\",\"selector\":{\"type\":\"FragmentSelector\",\"conformsTo\":\"http://www.w3.org/TR/media-frags/\",\"value\":\"xywh=pixel:68,76,194,196\"}},\"id\":\"#48d7b458-fead-45af-b317-db2d9ddf4c38\"}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:10:52 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "79"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation failed\",\n    \"error\": \"annotation_id already exists\"\n}"
+				}
+			]
+		},
+		{
+			"name": "Image Create Bad Request",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "annotation_type",
+							"value": "image",
+							"type": "text"
+						},
+						{
+							"key": "content_id",
+							"value": "1",
+							"type": "text"
+						},
+						{
+							"key": "jsonld",
+							"value": "{\"@context\"",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "localhost:8000/contmgr/annotations/",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"contmgr",
+						"annotations",
+						""
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Image Create Bad Request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "imagey",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"text annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":\"1\",\"name\":\"tollen\"},\"created\":\"2022-12-23T14:48:30.744Z\",\"modified\":\"2022-12-23T14:48:38.590Z\"}],\"target\":{\"selector\":[{\"type\":\"TextQuoteSelector\",\"exact\":\"Annotations\"},{\"type\":\"TextPositionSelector\",\"start\":14,\"end\":25}]},\"id\":\"#5519fef0-7376-4630-96f8-4b6407419c13\"}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:12:33 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "77"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation failed\",\n    \"error\": \"annotation_type is invalid\"\n}"
+				},
+				{
+					"name": "Image Create Bad Request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "image",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "5",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"text annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":\"1\",\"name\":\"tollen\"},\"created\":\"2022-12-23T14:48:30.744Z\",\"modified\":\"2022-12-23T14:48:38.590Z\"}],\"target\":{\"selector\":[{\"type\":\"TextQuoteSelector\",\"exact\":\"Annotations\"},{\"type\":\"TextPositionSelector\",\"start\":14,\"end\":25}]},\"id\":\"#5519fef0-7376-4630-96f8-4b6407419c13\"}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Not Found",
+					"code": 404,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:12:46 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "71"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation failed\",\n    \"error\": \"post does not exists\"\n}"
+				},
+				{
+					"name": "Image Create Bad Request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "image",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"@context\"",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:13:03 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "68"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation failed\",\n    \"error\": \"jsonld is invalid\"\n}"
+				}
+			]
+		},
+		{
+			"name": "Text Create Bad Request",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "annotation_type",
+							"value": "text",
+							"type": "text"
+						},
+						{
+							"key": "content_type",
+							"value": "post",
+							"type": "text"
+						},
+						{
+							"key": "content_id",
+							"value": "1",
+							"type": "text"
+						},
+						{
+							"key": "jsonld",
+							"value": "{\"test\"",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "localhost:8000/contmgr/annotations/",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"contmgr",
+						"annotations",
+						""
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Create Bad Request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "texty",
+									"type": "text"
+								},
+								{
+									"key": "content_type",
+									"value": "post",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"text annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":\"1\",\"name\":\"tollen\"},\"created\":\"2022-12-23T14:48:30.744Z\",\"modified\":\"2022-12-23T14:48:38.590Z\"}],\"target\":{\"selector\":[{\"type\":\"TextQuoteSelector\",\"exact\":\"Annotations\"},{\"type\":\"TextPositionSelector\",\"start\":14,\"end\":25}]},\"id\":\"#5519fef0-7376-4630-96f8-4b6407419c13\"}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:00:01 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "77"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation failed\",\n    \"error\": \"annotation_type is invalid\"\n}"
+				},
+				{
+					"name": "Create Bad Request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "text",
+									"type": "text"
+								},
+								{
+									"key": "content_type",
+									"value": "posty",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"text annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":\"1\",\"name\":\"tollen\"},\"created\":\"2022-12-23T14:48:30.744Z\",\"modified\":\"2022-12-23T14:48:38.590Z\"}],\"target\":{\"selector\":[{\"type\":\"TextQuoteSelector\",\"exact\":\"Annotations\"},{\"type\":\"TextPositionSelector\",\"start\":14,\"end\":25}]},\"id\":\"#5519fef0-7376-4630-96f8-4b6407419c13\"}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:00:57 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "74"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation failed\",\n    \"error\": \"content_type is invalid\"\n}"
+				},
+				{
+					"name": "Create Bad Request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "text",
+									"type": "text"
+								},
+								{
+									"key": "content_type",
+									"value": "post",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "5",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"@context\":\"http://www.w3.org/ns/anno.jsonld\",\"type\":\"Annotation\",\"body\":[{\"type\":\"TextualBody\",\"value\":\"text annotation\",\"purpose\":\"commenting\",\"creator\":{\"id\":\"1\",\"name\":\"tollen\"},\"created\":\"2022-12-23T14:48:30.744Z\",\"modified\":\"2022-12-23T14:48:38.590Z\"}],\"target\":{\"selector\":[{\"type\":\"TextQuoteSelector\",\"exact\":\"Annotations\"},{\"type\":\"TextPositionSelector\",\"start\":14,\"end\":25}]},\"id\":\"#5519fef0-7376-4630-96f8-4b6407419c13\"}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Not Found",
+					"code": 404,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:01:13 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "71"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation failed\",\n    \"error\": \"post does not exists\"\n}"
+				},
+				{
+					"name": "Create Bad Request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_type",
+									"value": "text",
+									"type": "text"
+								},
+								{
+									"key": "content_type",
+									"value": "post",
+									"type": "text"
+								},
+								{
+									"key": "content_id",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "jsonld",
+									"value": "{\"test\"",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:01:59 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "68"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation creation failed\",\n    \"error\": \"jsonld is invalid\"\n}"
+				}
+			]
+		},
+		{
+			"name": "Delete Bad request",
+			"request": {
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+						"type": "default"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "annotation_id",
+							"value": "#5519fef0-7376-4630-96f8-4b6407419c13",
+							"type": "text"
+						},
+						{
+							"key": "annotation_type",
+							"value": "text",
+							"type": "text",
+							"disabled": true
+						}
+					]
+				},
+				"url": {
+					"raw": "localhost:8000/contmgr/annotations/",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"contmgr",
+						"annotations",
+						""
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Delete Bad request",
+					"originalRequest": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_id",
+									"value": "#5519fef0-7376-4630-96f8-4b6407419c13",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 18:55:08 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "77"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation deletion failed\",\n    \"error\": \"annotation_type is missing\"\n}"
+				},
+				{
+					"name": "Delete Bad request",
+					"originalRequest": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_id",
+									"value": "#5519fef0-7376-4630-96f8-4b6407419c13",
+									"type": "text",
+									"disabled": true
+								},
+								{
+									"key": "annotation_type",
+									"value": "text",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:05:59 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "75"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation deletion failed\",\n    \"error\": \"annotation_id is missing\"\n}"
+				},
+				{
+					"name": "Delete Bad request",
+					"originalRequest": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_id",
+									"value": "#5519fef0-7376-4630-96f8-4b6407419c134",
+									"type": "text"
+								},
+								{
+									"key": "annotation_type",
+									"value": "text",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "Not Found",
+					"code": 404,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:06:09 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "77"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation deletion failed\",\n    \"error\": \"annotation does not exists\"\n}"
+				}
+			]
+		},
+		{
+			"name": "Delete Success",
+			"request": {
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+						"type": "default"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "annotation_id",
+							"value": "#5519fef0-7376-4630-96f8-4b6407419c13",
+							"type": "text"
+						},
+						{
+							"key": "annotation_type",
+							"value": "text",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "localhost:8000/contmgr/annotations/",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"contmgr",
+						"annotations",
+						""
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Delete Success",
+					"originalRequest": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_id",
+									"value": "#5519fef0-7376-4630-96f8-4b6407419c13",
+									"type": "text"
+								},
+								{
+									"key": "annotation_type",
+									"value": "text",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 18:56:16 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "42"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation deletion successful\"\n}"
+				},
+				{
+					"name": "Delete Success",
+					"originalRequest": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Token 60ce1bfd6d070ccf9118f512ed6ac4e46ff9637f",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "annotation_id",
+									"value": "#48d7b458-fead-45af-b317-db2d9ddf4c38",
+									"type": "text"
+								},
+								{
+									"key": "annotation_type",
+									"value": "image",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "localhost:8000/contmgr/annotations/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"contmgr",
+								"annotations",
+								""
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sat, 24 Dec 2022 19:15:31 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "POST, DELETE, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "42"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"annotation deletion successful\"\n}"
+				}
+			]
+		}
+	]
+}

--- a/Application/Backend/docker_backend/Dockerfile
+++ b/Application/Backend/docker_backend/Dockerfile
@@ -18,6 +18,7 @@ COPY ./src /backend/django/src
 COPY ./docker_backend/test_settings.py /backend/django/src/settings.py
 RUN python manage.py makemigrations
 RUN python manage.py migrate
+RUN python manage.py migrate --database=annotation
 RUN python manage.py test
 
 # Cleanup and replacement

--- a/Application/Backend/docker_backend/init_backend.sh
+++ b/Application/Backend/docker_backend/init_backend.sh
@@ -18,6 +18,8 @@ python manage.py makemigrations
 python manage.py makemigrations accmgr
 python manage.py migrate accmgr --fake-initial
 python manage.py migrate --run-syncdb
+python manage.py migrate --database=annotation
+python manage.py migrate --database=annotation --run-syncdb
 
 # Create debug superuser if username given
 if [ "$DJANGO_SUPERUSER_USERNAME" ]

--- a/Application/Backend/src/contmgr/models.py
+++ b/Application/Backend/src/contmgr/models.py
@@ -76,3 +76,16 @@ class Label(models.Model):
             "labelColor": self.labelColor,
             "parentLabel": self.parentLabel.labelID if self.parentLabel else None
         }
+
+class TextAnnotation(models.Model):
+
+    id = models.CharField(max_length=64, primary_key=True)
+    content_type = models.CharField(max_length=1, choices=(("p", "post"), ("c", "comment")), blank=False, null=False)
+    content_id = models.IntegerField(blank=False, null=False)
+    jsonld = models.JSONField(blank=False, null=False)
+
+class ImageAnnotation(models.Model):
+
+    id = models.CharField(max_length=64, primary_key=True)
+    content_id = models.IntegerField(blank=False, null=False)
+    jsonld = models.JSONField(blank=False, null=False)

--- a/Application/Backend/src/contmgr/models.py
+++ b/Application/Backend/src/contmgr/models.py
@@ -80,6 +80,7 @@ class Label(models.Model):
 class TextAnnotation(models.Model):
 
     id = models.CharField(max_length=64, primary_key=True)
+    author = models.ForeignKey(RegisteredUser, on_delete=models.CASCADE, blank=False, null=False)
     content_type = models.CharField(max_length=1, choices=(("p", "post"), ("c", "comment")), blank=False, null=False)
     content_id = models.IntegerField(blank=False, null=False)
     jsonld = models.JSONField(blank=False, null=False)
@@ -87,5 +88,6 @@ class TextAnnotation(models.Model):
 class ImageAnnotation(models.Model):
 
     id = models.CharField(max_length=64, primary_key=True)
+    author = models.ForeignKey(RegisteredUser, on_delete=models.CASCADE, blank=False, null=False)
     content_id = models.IntegerField(blank=False, null=False)
     jsonld = models.JSONField(blank=False, null=False)

--- a/Application/Backend/src/contmgr/models.py
+++ b/Application/Backend/src/contmgr/models.py
@@ -80,7 +80,7 @@ class Label(models.Model):
 class TextAnnotation(models.Model):
 
     id = models.CharField(max_length=64, primary_key=True)
-    author = models.ForeignKey(RegisteredUser, on_delete=models.CASCADE, blank=False, null=False)
+    author_id = models.IntegerField(blank=False, null=False)
     content_type = models.CharField(max_length=1, choices=(("p", "post"), ("c", "comment")), blank=False, null=False)
     content_id = models.IntegerField(blank=False, null=False)
     jsonld = models.JSONField(blank=False, null=False)
@@ -88,6 +88,6 @@ class TextAnnotation(models.Model):
 class ImageAnnotation(models.Model):
 
     id = models.CharField(max_length=64, primary_key=True)
-    author = models.ForeignKey(RegisteredUser, on_delete=models.CASCADE, blank=False, null=False)
+    author_id = models.IntegerField(blank=False, null=False)
     content_id = models.IntegerField(blank=False, null=False)
     jsonld = models.JSONField(blank=False, null=False)

--- a/Application/Backend/src/contmgr/routers.py
+++ b/Application/Backend/src/contmgr/routers.py
@@ -1,0 +1,20 @@
+from .models import TextAnnotation, ImageAnnotation
+from ..accmgr.models import RegisteredUser
+
+class AnnotationDBRouter:
+
+    def db_for_read(self, model, **hints):
+        if model == TextAnnotation or model == ImageAnnotation:
+            return 'annotation'
+        return None
+
+    def db_for_write(self, model, **hints):
+        if model == TextAnnotation or model == ImageAnnotation:
+            return 'annotation'
+        return None
+
+    def allow_relation(self, obj1, obj2, **hints):
+        return True
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        return True

--- a/Application/Backend/src/contmgr/routers.py
+++ b/Application/Backend/src/contmgr/routers.py
@@ -17,4 +17,6 @@ class AnnotationDBRouter:
         return True
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
-        return True
+        if model_name=="textannotation" or model_name=="imageannotation":
+            return db == 'annotation'
+        return None

--- a/Application/Backend/src/contmgr/tests.py
+++ b/Application/Backend/src/contmgr/tests.py
@@ -22,6 +22,8 @@ def registerUsers(client):
     
 class PostsTest(TestCase):
 
+    databases = ['default', 'annotation']
+
     def setUp(self):
         self.client = Client()
         self.tokens = registerUsers(self.client)
@@ -60,6 +62,8 @@ class PostsTest(TestCase):
         self.assertEqual(content["type"], 'q')
 
 class CommentsTest(TestCase):
+
+    databases = ['default', 'annotation']
 
     def setUp(self):
         self.client = Client()
@@ -231,3 +235,53 @@ class SearchPostTest(TestCase):
         postIDs = [post["postID"] for post in posts]
         self.assertEqual(postIDs, [3, 4])
 
+class AnnotationTest(TestCase):
+
+    databases = ["default", "annotation"]
+
+    def setUp(self):
+        def postCreate(number):
+            response = self.client.post('/contmgr/post/', { "title": f"title {number}", "type": "q",
+                    "description": "Constant headache while sleeping"}, HTTP_AUTHORIZATION=f"Token {self.tokens[number]}")
+            return json.loads(response.content)["postID"]
+        self.client = Client()
+        self.tokens = registerUsers(self.client)
+        self.postID = [postCreate(_num) for _num in range(3)]
+
+    def test_text_annotation(self):
+        response = self.client.post('/contmgr/annotations/', { "annotation_type": "text",
+                                                                "content_type": "post",
+                                                                "content_id": 1,
+                                                                "jsonld": '{"@context":"http://www.w3.org/ns/anno.jsonld","type":"Annotation","body":[{"type":"TextualBody","value":"text annotation","purpose":"commenting","creator":{"id":"1","name":"tollen"},"created":"2022-12-23T14:48:30.744Z","modified":"2022-12-23T14:48:38.590Z"}],"target":{"selector":[{"type":"TextQuoteSelector","exact":"Annotations"},{"type":"TextPositionSelector","start":14,"end":25}]},"id":"#5519fef0-7376-4630-96f8-4b6407419c13"}'}, HTTP_AUTHORIZATION=f"Token {self.tokens[0]}")
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {
+            "info": "annotation creation successful",
+            "annotation_id": "#5519fef0-7376-4630-96f8-4b6407419c13"
+        })
+
+    def test_image_annotation(self):
+        response = self.client.post('/contmgr/annotations/', { "annotation_type": "image",
+                                                                "content_type": "post",
+                                                                "content_id": 1,
+                                                                "jsonld": '{"@context":"http://www.w3.org/ns/anno.jsonld","type":"Annotation","body":[{"type":"TextualBody","value":"image annotation","purpose":"commenting","creator":{"id":1,"name":"tollen"},"created":"2022-12-23T14:55:40.253Z","modified":"2022-12-23T14:55:41.743Z"}],"target":{"source":"https://myuploads-medishare38.s3.amazonaws.com/image_1671788232333.png","selector":{"type":"FragmentSelector","conformsTo":"http://www.w3.org/TR/media-frags/","value":"xywh=pixel:68,76,194,196"}},"id":"#48d7b458-fead-45af-b317-db2d9ddf4c38"}'
+        }, HTTP_AUTHORIZATION=f"Token {self.tokens[0]}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {
+            "info": "annotation creation successful",
+            "annotation_id": "#48d7b458-fead-45af-b317-db2d9ddf4c38"
+        })
+
+    def test_bad_request(self):
+        response = self.client.post('/contmgr/annotations/', { "annotation_type": "video",
+                                                                "content_type": "post",
+                                                                "content_id": 1,
+                                                                "jsonld": '{"@context":"http://www.w3.org/ns/anno.jsonld","type":"Annotation","body":[{"type":"TextualBody","value":"image annotation","purpose":"commenting","creator":{"id":1,"name":"tollen"},"created":"2022-12-23T14:55:40.253Z","modified":"2022-12-23T14:55:41.743Z"}],"target":{"source":"https://myuploads-medishare38.s3.amazonaws.com/image_1671788232333.png","selector":{"type":"FragmentSelector","conformsTo":"http://www.w3.org/TR/media-frags/","value":"xywh=pixel:68,76,194,196"}},"id":"#48d7b458-fead-45af-b317-db2d9ddf4c38"}'
+        }, HTTP_AUTHORIZATION=f"Token {self.tokens[0]}")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.content), {
+            "info": "annotation creation failed",
+            "error": "annotation_type is invalid"
+        })

--- a/Application/Backend/src/contmgr/urls.py
+++ b/Application/Backend/src/contmgr/urls.py
@@ -16,4 +16,6 @@ urlpatterns = [
     path('commentvote/', views.CommentVote.as_view(), name='comment'),
     path('allposts', views.AllPostsView.as_view(), name='allposts'),
     path('allposts/', views.AllPostsView.as_view(), name='allposts/'),
+    path('annotations', views.AnnotationView.as_view(), name='annotations'),
+    path('annotations/', views.AnnotationView.as_view(), name='annotations/'),
 ]

--- a/Application/Backend/src/contmgr/views.py
+++ b/Application/Backend/src/contmgr/views.py
@@ -446,7 +446,7 @@ class AnnotationView(APIView):
                 if post is None:
                     return JsonResponse({"info":"annotation creation failed", "error": "post does not exists"}, status=404)
 
-                annotation = TextAnnotation(id=annotation_id, author=user, content_type=content_type[0], content_id=content_id, jsonld=jsonld_dict)
+                annotation = TextAnnotation(id=annotation_id, author_id=user.userID, content_type=content_type[0], content_id=content_id, jsonld=jsonld_dict)
                 
                 try:
                     annotation.save(using="annotation")
@@ -461,7 +461,7 @@ class AnnotationView(APIView):
                 if comment is None:
                     return JsonResponse({"info":"annotation creation failed", "error": "comment does not exists"}, status=404)
 
-                annotation = TextAnnotation(id=annotation_id, author=user, content_type=content_type[0], content_id=content_id, jsonld=jsonld_dict)
+                annotation = TextAnnotation(id=annotation_id, author_id=user.userID, content_type=content_type[0], content_id=content_id, jsonld=jsonld_dict)
                 
                 try:
                     annotation.save(using="annotation")
@@ -487,7 +487,7 @@ class AnnotationView(APIView):
             if annotation_id is None:
                 return JsonResponse({"info":"annotation creation failed", "error": "annotation_id is missing"}, status=400)
 
-            annotation = ImageAnnotation(id=annotation_id, author=user, content_id=content_id, jsonld=jsonld_dict)
+            annotation = ImageAnnotation(id=annotation_id, author_id=user.userID, content_id=content_id, jsonld=jsonld_dict)
 
             try:
                 annotation.save(using="annotation")

--- a/Application/Backend/src/contmgr/views.py
+++ b/Application/Backend/src/contmgr/views.py
@@ -239,7 +239,7 @@ class CommentView(APIView):
         try:
             mentioned_users = [RegisteredUser.objects.get(username=_user) for _user in _mentioned_users]
         except:
-            return JsonResponse({"info":"comment creation failed", "error": f"mentioned_users does not exists on database"}, status=400)
+            return JsonResponse({"info":"comment creation failed", "error": f"mentioned_users does not exists on database"}, status=404)
 
         try:
             new_comment.mentioned_users.set(mentioned_users, clear=True)
@@ -374,7 +374,7 @@ class PostView(APIView):
             labels = [Label.objects.get(labelID=_label) for _label in _labels]
             mentioned_users = [RegisteredUser.objects.get(username=_user) for _user in _mentioned_users]
         except:
-            return JsonResponse({"info":"post creation failed", "error": f"labels or mentioned_users does not exists on database"}, status=400)
+            return JsonResponse({"info":"post creation failed", "error": f"labels or mentioned_users does not exists on database"}, status=404)
 
         new_post = Post(title=_title, type=_type, location=_location, imageURL = _imageURL,
                         is_marked_nsfw=_is_marked_nsfw, owner=user, description=_description)
@@ -444,7 +444,7 @@ class AnnotationView(APIView):
                 post = Post.objects.filter(postID=content_id).first()
                 
                 if post is None:
-                    return JsonResponse({"info":"annotation creation failed", "error": "post does not exists"}, status=400)
+                    return JsonResponse({"info":"annotation creation failed", "error": "post does not exists"}, status=404)
 
                 annotation = TextAnnotation(id=annotation_id, author=user, content_type=content_type[0], content_id=content_id, jsonld=jsonld)
                 
@@ -459,7 +459,7 @@ class AnnotationView(APIView):
                 comment = Comment.objects.filter(commentID=content_id).first()
                 
                 if comment is None:
-                    return JsonResponse({"info":"annotation creation failed", "error": "comment does not exists"}, status=400)
+                    return JsonResponse({"info":"annotation creation failed", "error": "comment does not exists"}, status=404)
 
                 annotation = TextAnnotation(id=annotation_id, author=user, content_type=content_type[0], content_id=content_id, jsonld=jsonld)
                 

--- a/Application/Backend/src/contmgr/views.py
+++ b/Application/Backend/src/contmgr/views.py
@@ -497,3 +497,46 @@ class AnnotationView(APIView):
 
         else:
             return JsonResponse({"info":"annotation creation failed", "error": "annotation_type is invalid"}, status=400)
+
+    def delete(self, req):
+
+        user = req.user
+
+        annotation_type = req.POST.get("annotation_type", None)
+
+        if annotation_type is None:
+            return JsonResponse({"info":"annotation deletion failed", "error": "annotation_type is missing"}, status=400)
+
+        if annotation_type == "text":
+
+            annotation = TextAnnotation.objects.using("annotation").filter(id=req.POST.get("annotation_id", None)).first()
+
+            if annotation is None:
+                return JsonResponse({"info":"annotation deletion failed", "error": "annotation does not exists"}, status=404)
+
+            if annotation.author_id != user.userID:
+                return JsonResponse({"info":"annotation deletion failed", "error": "annotation does not belongs to you"}, status=403)
+
+            try:
+                annotation.delete(using="annotation")
+                return JsonResponse({"info": "annotation deletion successful"}, status=200)
+
+            except Exception as e:
+                return JsonResponse({"info":"annotation deletion failed", "error": str(e)}, status=500)
+
+        elif annotation_type == "image":
+
+            annotation = ImageAnnotation.objects.using("annotation").filter(id=req.POST.get("annotation_id", None)).first()
+
+            if annotation is None:
+                return JsonResponse({"info":"annotation deletion failed", "error": "annotation does not exists"}, status=404)
+
+            if annotation.author_id != user.userID:
+                return JsonResponse({"info":"annotation deletion failed", "error": "annotation does not belongs to you"}, status=403)
+
+            try:
+                annotation.delete(using="annotation")
+                return JsonResponse({"info": "annotation deletion successful"}, status=200)
+
+            except Exception as e:
+                return JsonResponse({"info":"annotation deletion failed", "error": str(e)}, status=500)

--- a/Application/Backend/src/contmgr/views.py
+++ b/Application/Backend/src/contmgr/views.py
@@ -278,6 +278,13 @@ class PostView(APIView):
         }
         
         comments = Comment.objects.filter(parent_post= tpost).order_by('created_at')
+
+        text_annotations = TextAnnotation.objects.filter(content_id= tpost.postID, content_type= "post")
+        data["text_annotations"] = [text_annotation.jsonld for text_annotation in text_annotations]
+
+        image_annotations = ImageAnnotation.objects.filter(content_id= tpost.postID, content_type= "post")
+        data["image_annotations"] = [image_annotation.jsonld for image_annotation in image_annotations]
+
         insertComments(data["comments"], comments)
         return JsonResponse(data, status=200)
 

--- a/Application/Backend/src/contmgr/views.py
+++ b/Application/Backend/src/contmgr/views.py
@@ -286,7 +286,7 @@ class PostView(APIView):
         text_annotations = TextAnnotation.objects.filter(content_id= tpost.postID, content_type= "post")
         data["text_annotations"] = [text_annotation.jsonld for text_annotation in text_annotations]
 
-        image_annotations = ImageAnnotation.objects.filter(content_id= tpost.postID, content_type= "post")
+        image_annotations = ImageAnnotation.objects.filter(content_id= tpost.postID)
         data["image_annotations"] = [image_annotation.jsonld for image_annotation in image_annotations]
 
         insertComments(data["comments"], comments)
@@ -446,7 +446,7 @@ class AnnotationView(APIView):
                 if post is None:
                     return JsonResponse({"info":"annotation creation failed", "error": "post does not exists"}, status=404)
 
-                annotation = TextAnnotation(id=annotation_id, author=user, content_type=content_type[0], content_id=content_id, jsonld=jsonld)
+                annotation = TextAnnotation(id=annotation_id, author=user, content_type=content_type[0], content_id=content_id, jsonld=jsonld_dict)
                 
                 try:
                     annotation.save(using="annotation")
@@ -461,7 +461,7 @@ class AnnotationView(APIView):
                 if comment is None:
                     return JsonResponse({"info":"annotation creation failed", "error": "comment does not exists"}, status=404)
 
-                annotation = TextAnnotation(id=annotation_id, author=user, content_type=content_type[0], content_id=content_id, jsonld=jsonld)
+                annotation = TextAnnotation(id=annotation_id, author=user, content_type=content_type[0], content_id=content_id, jsonld=jsonld_dict)
                 
                 try:
                     annotation.save(using="annotation")
@@ -487,7 +487,7 @@ class AnnotationView(APIView):
             if annotation_id is None:
                 return JsonResponse({"info":"annotation creation failed", "error": "annotation_id is missing"}, status=400)
 
-            annotation = ImageAnnotation(id=annotation_id, author=user, content_id=content_id, jsonld=jsonld)
+            annotation = ImageAnnotation(id=annotation_id, author=user, content_id=content_id, jsonld=jsonld_dict)
 
             try:
                 annotation.save(using="annotation")

--- a/Application/Backend/src/contmgr/views.py
+++ b/Application/Backend/src/contmgr/views.py
@@ -166,7 +166,7 @@ class CommentView(APIView):
         insertComments(data, [comment])
         # Return first one (Only one element will return)
 
-        text_annotations = TextAnnotation.objects.filter(content_id = commentID, content_type = "comment")
+        text_annotations = TextAnnotation.objects.using("annotation").filter(content_id = commentID, content_type = "c")
         data[0]["text_annotations"] = [text_annotation.jsonld for text_annotation in text_annotations]
 
         return JsonResponse(data[0], status=200)
@@ -283,10 +283,10 @@ class PostView(APIView):
         
         comments = Comment.objects.filter(parent_post= tpost).order_by('created_at')
 
-        text_annotations = TextAnnotation.objects.filter(content_id= tpost.postID, content_type= "post")
+        text_annotations = TextAnnotation.objects.using("annotation").filter(content_id= tpost.postID, content_type= "p")
         data["text_annotations"] = [text_annotation.jsonld for text_annotation in text_annotations]
 
-        image_annotations = ImageAnnotation.objects.filter(content_id= tpost.postID)
+        image_annotations = ImageAnnotation.objects.using("annotation").filter(content_id= tpost.postID)
         data["image_annotations"] = [image_annotation.jsonld for image_annotation in image_annotations]
 
         insertComments(data["comments"], comments)

--- a/Application/Backend/src/contmgr/views.py
+++ b/Application/Backend/src/contmgr/views.py
@@ -165,6 +165,10 @@ class CommentView(APIView):
         data = []
         insertComments(data, [comment])
         # Return first one (Only one element will return)
+
+        text_annotations = TextAnnotation.objects.filter(content_id = commentID, content_type = "comment")
+        data[0]["text_annotations"] = [text_annotation.jsonld for text_annotation in text_annotations]
+
         return JsonResponse(data[0], status=200)
 
     def put(self, req):

--- a/Application/Backend/src/settings.py
+++ b/Application/Backend/src/settings.py
@@ -85,6 +85,8 @@ WSGI_APPLICATION = 'src.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
+DATABASE_ROUTERS = ['src.contmgr.routers.AnnotationDBRouter']
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',


### PR DESCRIPTION
The supporting features and endpoints for text and image annotations are implemented.

With the endpoints implemented, you can annotate the texts and images in a post, or annotate text in a comment. Additionally, you can delete annotations if you are the author of them.

The annotations are kept in a separate database of their own but they are returned with the get method of posts and comments.