### PR TITLE
Implementing Reputation Field for Users and ViewProfile Endpoint

### DIFF
--- a/Application/Backend/api_docs/viewprofile_api_doc.json
+++ b/Application/Backend/api_docs/viewprofile_api_doc.json
@@ -1,0 +1,197 @@
+{
+	"info": {
+		"_postman_id": "f604be0e-974b-43c5-991f-47f19ee84079",
+		"name": "ViewProfile",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Success",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:8000/viewprofile/?username=nancy",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"viewprofile",
+						""
+					],
+					"query": [
+						{
+							"key": "username",
+							"value": "nancy"
+						}
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Success",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "localhost:8000/viewprofile/?username=nancy",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"viewprofile",
+								""
+							],
+							"query": [
+								{
+									"key": "username",
+									"value": "nancy"
+								}
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sun, 25 Dec 2022 12:32:01 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "GET, HEAD, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "352"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"username\": \"nancy\",\n    \"email\": \"nancy@facadeledger.com\",\n    \"birth_date\": \"1970-10-06\",\n    \"gender\": \"M\",\n    \"is_messaging_allowed\": true,\n    \"is_notifications_allowed\": true,\n    \"reputation\": 0,\n    \"first_name\": null,\n    \"last_name\": null,\n    \"profile_picture\": null,\n    \"phone_number\": null,\n    \"verified_as_doctor\": false,\n    \"profession\": null,\n    \"location\": null,\n    \"diplomaID\": null\n}"
+				}
+			]
+		},
+		{
+			"name": "Username Missing",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:8000/viewprofile/?username=nancy",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"viewprofile",
+						""
+					],
+					"query": [
+						{
+							"key": "username",
+							"value": "nancy"
+						}
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Success Copy",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "localhost:8000/viewprofile/",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"viewprofile",
+								""
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Sun, 25 Dec 2022 12:32:57 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "WSGIServer/0.2 CPython/3.10.9"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept, Origin"
+						},
+						{
+							"key": "Allow",
+							"value": "GET, HEAD, OPTIONS"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Length",
+							"value": "61"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "Referrer-Policy",
+							"value": "same-origin"
+						},
+						{
+							"key": "Cross-Origin-Opener-Policy",
+							"value": "same-origin"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"info\": \"ViewProfile failed\",\n    \"error\": \"Username not given\"\n}"
+				}
+			]
+		}
+	]
+}

--- a/Application/Backend/src/accmgr/models.py
+++ b/Application/Backend/src/accmgr/models.py
@@ -31,6 +31,7 @@ class RegisteredUser(AbstractUser):
     first_name = None
     last_name = None
     groups = None
+    reputation = models.IntegerField()
 
     def save(self, *args, **kwargs):
         self.full_clean()

--- a/Application/Backend/src/accmgr/models.py
+++ b/Application/Backend/src/accmgr/models.py
@@ -31,7 +31,7 @@ class RegisteredUser(AbstractUser):
     first_name = None
     last_name = None
     groups = None
-    reputation = models.IntegerField()
+    reputation = models.IntegerField(default=0)
 
     def save(self, *args, **kwargs):
         self.full_clean()

--- a/Application/Backend/src/accmgr/tests.py
+++ b/Application/Backend/src/accmgr/tests.py
@@ -209,7 +209,7 @@ class ProfileTest(TestCase):
 
             response = self.client.get('/profile/', HTTP_AUTHORIZATION="Token " + token)
             response_content = json.loads(response.content)
-            self.assertEqual(response_content, {
+            self.assertDictEqual(response_content, {
                 "username": "markine",
                 "email": "markine@facadeledger.com",
                 "birth_date": "1988-03-12",
@@ -223,7 +223,8 @@ class ProfileTest(TestCase):
                 "verified_as_doctor": False,
                 "profession": None,
                 "location": None,
-                "diplomaID": None
+                "diplomaID": None,
+                "reputation": 0
             })
 
         def test_success_post(self):
@@ -237,7 +238,7 @@ class ProfileTest(TestCase):
 
             response_get = self.client.get('/profile/', HTTP_AUTHORIZATION="Token " + token)
             response_content_get = json.loads(response_get.content)
-            self.assertEqual(response_content_get, {
+            self.assertDictEqual(response_content_get, {
                 "username": "markine",
                 "email": "markine@facadeledger.com",
                 "birth_date": "1988-03-12",
@@ -251,7 +252,8 @@ class ProfileTest(TestCase):
                 "verified_as_doctor": False,
                 "profession": None,
                 "location": None,
-                "diplomaID": None
+                "diplomaID": None,
+                "reputation": 0
             })
 
         def test_invalid_birth_date(self):

--- a/Application/Backend/src/accmgr/tests.py
+++ b/Application/Backend/src/accmgr/tests.py
@@ -235,7 +235,7 @@ class ProfileTest(TestCase):
             self.assertEqual(response_content_get["is_messaging_allowed"], True)
             self.assertEqual(response_content_get["is_notification_allowed"], True)
             self.assertEqual(response_content_get["first_name"], "Markine Sun Beach")
-            self.assertEqual(response_content["reputation"], 0)
+            self.assertEqual(response_content_get["reputation"], 0)
 
         def test_invalid_birth_date(self):
             

--- a/Application/Backend/src/accmgr/urls.py
+++ b/Application/Backend/src/accmgr/urls.py
@@ -10,6 +10,6 @@ urlpatterns = [
     path('logout/', views.LogoutUser.as_view(), name="logout/"),
     path('profile', views.Profile.as_view(), name="profile"),
     path('profile/', views.Profile.as_view(), name="profile/"),
-    path('viewprofile', views.Profile.as_view(), name="profile"),
-    path('viewprofile/', views.Profile.as_view(), name="profile/"),
+    path('viewprofile', views.ViewProfile.as_view(), name="viewprofile"),
+    path('viewprofile/', views.ViewProfile.as_view(), name="viewprofile/"),
 ]

--- a/Application/Backend/src/accmgr/urls.py
+++ b/Application/Backend/src/accmgr/urls.py
@@ -10,4 +10,6 @@ urlpatterns = [
     path('logout/', views.LogoutUser.as_view(), name="logout/"),
     path('profile', views.Profile.as_view(), name="profile"),
     path('profile/', views.Profile.as_view(), name="profile/"),
+    path('viewprofile', views.Profile.as_view(), name="profile"),
+    path('viewprofile/', views.Profile.as_view(), name="profile/"),
 ]

--- a/Application/Backend/src/accmgr/views.py
+++ b/Application/Backend/src/accmgr/views.py
@@ -294,7 +294,7 @@ class ViewProfile(APIView):
 
     def get(self, req):
         try:
-            _username = req.GET["username", None]
+            _username = req.GET["username"]
         except:
             return JsonResponse({"info":f"ViewProfile failed", "error": "Username not given"}, status=400)
             

--- a/Application/Backend/src/accmgr/views.py
+++ b/Application/Backend/src/accmgr/views.py
@@ -163,6 +163,7 @@ class Profile(APIView):
             "gender": user.gender,
             "is_messaging_allowed": user.is_messaging_allowed,
             "is_notifications_allowed": user.is_notification_allowed,
+            "reputation": user.reputation,
 
             "first_name": account.first_name,
             "last_name": account.last_name,
@@ -285,3 +286,41 @@ class Profile(APIView):
 
         except:
             return JsonResponse({"error": "account cannot be deleted"}, status=400)
+
+
+class ViewProfile(APIView):
+
+    permission_classes = (AllowAny,)
+
+    def get(self, req):
+        try:
+            _username = req.GET["username", None]
+        except:
+            return JsonResponse({"info":f"ViewProfile failed", "error": "Username not given"}, status=400)
+            
+        # Parse all fields
+        _username = _username.strip().lower()
+
+        user = RegisteredUser.objects.get(username=_username)
+        account = Account.objects.get(owner=user)
+        profile_data = {
+
+            "username": user.username,
+            "email": user.email,
+            "birth_date": user.birth_date,
+            "gender": user.gender,
+            "is_messaging_allowed": user.is_messaging_allowed,
+            "is_notifications_allowed": user.is_notification_allowed,
+            "reputation": user.reputation,
+
+            "first_name": account.first_name,
+            "last_name": account.last_name,
+            "profile_picture": account.profile_picture,
+            "phone_number": account.phone_number,
+            "verified_as_doctor": account.verified_as_doctor,
+            "profession": account.profession,
+            "location": account.location,
+            "diplomaID": account.diplomaID,
+        }
+
+        return JsonResponse(profile_data, status=200)

--- a/Application/Backend/src/accmgr/views.py
+++ b/Application/Backend/src/accmgr/views.py
@@ -286,25 +286,7 @@ class ViewProfile(APIView):
         _username = _username.strip().lower()
 
         user = RegisteredUser.objects.get(username=_username)
-        account = Account.objects.get(owner=user)
-        profile_data = {
+        
+        data = RegisteredUserSerializer(user).data
 
-            "username": user.username,
-            "email": user.email,
-            "birth_date": user.birth_date,
-            "gender": user.gender,
-            "is_messaging_allowed": user.is_messaging_allowed,
-            "is_notifications_allowed": user.is_notification_allowed,
-            "reputation": user.reputation,
-
-            "first_name": account.first_name,
-            "last_name": account.last_name,
-            "profile_picture": account.profile_picture,
-            "phone_number": account.phone_number,
-            "verified_as_doctor": account.verified_as_doctor,
-            "profession": account.profession,
-            "location": account.location,
-            "diplomaID": account.diplomaID,
-        }
-
-        return JsonResponse(profile_data, status=200)
+        return JsonResponse(data, status=200)

--- a/Application/Backend/src/contmgr/tests.py
+++ b/Application/Backend/src/contmgr/tests.py
@@ -4,6 +4,7 @@ import json
 
 # This function is here to set up some test classes.
 # This function registers some users, and returns tokens of them.
+mock_usernames = ["markine", "john", "nancy", "mary"]
 def registerUsers(client):
 # This function helps to login and acquire token of specific user
     def login_helper(user, passwd):
@@ -18,7 +19,7 @@ def registerUsers(client):
             "password": "passpass", "gender":"o", "birth_day":"26", "birth_month":"11", "birth_year":"1980"})
     client.post('/register/', { "username": "mary", "email": "mary@facadeledger.com",
             "password": "passpass", "gender":"o", "birth_day":"26", "birth_month":"11", "birth_year":"1980"})
-    return [login_helper(_user, "passpass") for _user in ["markine", "john", "nancy", "mary"]]
+    return [login_helper(_user, "passpass") for _user in mock_usernames]
     
 class PostsTest(TestCase):
 
@@ -129,28 +130,46 @@ class VoteTest(TestCase):
     
     def test_votes(self):
         # Test vote
-        response = self.client.post('/contmgr/postvote/', { "id": self.postID[0], "vote": "up"}, 
+        response = self.client.post('/contmgr/postvote/', { "id": self.postID[1], "vote": "up"}, 
                 HTTP_AUTHORIZATION=f"Token {self.tokens[0]}")
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(content["info"], "Upvote added to post for user")
 
+        # Check user reputation after vote
+        response = self.client.get(f'/viewprofile?username={mock_usernames[1]}')
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content["reputation"], 1)
+
+        response = self.client.post('/contmgr/postvote/', { "id": self.postID[1], "vote": "down"}, 
+                HTTP_AUTHORIZATION=f"Token {self.tokens[2]}")
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(content["info"], "Downvote added to post for user")
+
         # Test vote change
-        response = self.client.post('/contmgr/postvote/', { "id": self.postID[0], "vote": "down"}, 
+        response = self.client.post('/contmgr/postvote/', { "id": self.postID[1], "vote": "down"}, 
                 HTTP_AUTHORIZATION=f"Token {self.tokens[0]}")
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(content["info"], "Downvote added to post for user")
 
         # Check vote
-        response = self.client.get(f'/contmgr/postvote?id={self.postID[0]}', 
+        response = self.client.get(f'/contmgr/postvote?id={self.postID[1]}', 
                 HTTP_AUTHORIZATION=f"Token {self.tokens[0]}")
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(content["voted"], "down")
+
+        # Check user reputation after votes
+        response = self.client.get(f'/viewprofile?username={mock_usernames[1]}')
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content["reputation"], -2)
         
         # Remove vote
-        response = self.client.post('/contmgr/postvote/', { "id": self.postID[0], "vote": "down"}, 
+        response = self.client.post('/contmgr/postvote/', { "id": self.postID[1], "vote": "down"}, 
                 HTTP_AUTHORIZATION=f"Token {self.tokens[0]}")
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 201)

--- a/Application/Backend/src/contmgr/views.py
+++ b/Application/Backend/src/contmgr/views.py
@@ -98,6 +98,7 @@ class Vote(APIView):
 
     def post(self, req, _type):
         user = RegisteredUser.objects.get(username=req.user)
+        rep_point = 1 if vote=="up" else -1
         try:
             modelID = int(req.POST.get("id", None))
             vote = req.POST["vote"].strip().lower()
@@ -117,6 +118,7 @@ class Vote(APIView):
             if main_vote.filter(username=user.username).exists():
                 try:
                     main_vote.remove(user)
+                    user.reputation-= rep_point
                     return JsonResponse({"info":f"{op_name} removed from {_type} for user"}, status=201)
                 except Exception as e:
                     return JsonResponse({"info":f"{op_name} remove from {_type} failed", "error": str(e)}, status=400)
@@ -124,7 +126,9 @@ class Vote(APIView):
                 try:
                     if side_vote.filter(username=user.username).exists():
                         side_vote.remove(user)
+                        user.reputation+= rep_point
                     main_vote.add(user)
+                    user.reputation+= rep_point
                     return JsonResponse({"info":f"{op_name} added to {_type} for user"}, status=201)
                 except Exception as e:
                     return JsonResponse({"info":f"{op_name} add to {_type} failed", "error": str(e)}, status=400)


### PR DESCRIPTION
Reputation filed for RegisteredUsers model and ViewProfile Endpoint with only GET method has been implemented. Required tests and documents have been written.
* ViewProfile should return the profile of any user with given username
* Reputation field for all users should start from 0 at registration, and should increase or decrease with total votes the user gets on their posts and comments.