### PR TITLE
Search Post Endpoint Now Returns Sorted Posts

### DIFF
--- a/Application/Backend/src/contmgr/tests.py
+++ b/Application/Backend/src/contmgr/tests.py
@@ -296,7 +296,7 @@ class SearchPostTest(TestCase):
         response_content = json.loads(response.content)
         posts = response_content["posts"]
         postIDs = [post["postID"] for post in posts]
-        self.assertEqual(postIDs, [3, 4])
+        self.assertEqual(postIDs, [4, 3])
 
 class AnnotationTest(TestCase):
 

--- a/Application/Backend/src/contmgr/views.py
+++ b/Application/Backend/src/contmgr/views.py
@@ -41,6 +41,8 @@ class SearchPost(APIView):
             for label in labels:
                 posts = posts.filter(labels__labelName=label)
 
+        posts = posts.order_by("-created_at")
+
         data = {"posts" : []}
         for post in posts:
             data["posts"].append(PostSerializer(post).data)


### PR DESCRIPTION
The search post endpoint now returns the posts in the order of the creation date. The posts are sorted from newest to oldest.